### PR TITLE
Added couchdb persistency. Added docker-compose.yml

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+COUCHDB=couchdb.kazoo
+#COUCHDB_USER=change_me
+#COUCHDB_PASSWORD=change_me
+KAZOO=kazoo.kazoo
+KAZOO_APPS=sysconf,blackhole,callflow,cdr,conference,crossbar,fax,hangups,media_mgr,milliwatt,omnipresence,pivot,registrar,reorder,stepswitch,teletype,trunkstore,webhooks,ecallmgr
+NETWORK=kazoo
+NODE_NAME=kazoo
+RABBITMQ=rabbitmq.kazoo
+#RABBITMQ_DEFAULT_USER=change_me
+#RABBITMQ_DEFAULT_PASS=change_me
+#RABBITMQ_DEFAULT_VHOST=/change_me
+RTP_START_PORT=10000

--- a/bin/run-couchdb.sh
+++ b/bin/run-couchdb.sh
@@ -15,5 +15,6 @@ echo -n "starting: $NAME "
 docker run $FLAGS \
 	--net $NETWORK \
 	-h $NAME \
+	-v "$(pwd)/couchdb_data:/usr/local/var/lib/couchdb:rw" \
 	--name $NAME \
 	2600hz/couchdb

--- a/bin/run-kazoo.sh
+++ b/bin/run-kazoo.sh
@@ -2,8 +2,14 @@
 FLAGS=${1:-"-td"}
 NETWORK=${NETWORK:-"kazoo"}
 NAME=kazoo.$NETWORK
-docker stop -t 1 $NAME
-docker rm -f $NAME
+if [ -n "$(docker ps -aq -f name=$NAME)" ]
+then
+   echo -n "stopping: "
+   docker stop -t 1 $NAME
+   echo -n "removing: "
+   docker rm -f $NAME
+fi
+echo -n "starting: $NAME "
 docker run $FLAGS \
 	--net $NETWORK \
 	-h $NAME \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,95 @@
+version: '2'
+
+networks:
+  kazoo:
+    driver: bridge
+
+services:
+  rabbitmq.kazoo:
+    image: 2600hz/rabbitmq
+    container_name: rabbitmq.kazoo 
+    hostname: rabbitmq.kazoo
+#    environment:
+#      - "RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}"
+#      - "RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}"
+#      - "RABBITMQ_DEFAULT_VHOST=${RABBITMQ_DEFAULT_VHOST}"
+    volumes:
+      - "/etc/localtime:/etc/localtime:ro"
+    ports:
+      - "5672"
+    networks:
+      - kazoo
+
+  couchdb.kazoo:
+    image: 2600hz/couchdb
+    container_name: couchdb.kazoo
+    hostname: couchdb.kazoo
+#    environment:
+#      - "COUCHDB_USER=${COUCHDB_USER}"
+#      - "COUCHDB_PASSWORD=${COUCHDB_PASSWORD}"
+    volumes:
+      - "/etc/localtime:/etc/localtime:ro"
+      - "./couchdb_data:/usr/local/var/lib/couchdb:rw"
+    depends_on:
+      - rabbitmq.kazoo
+    networks:
+      - kazoo
+
+  kazoo.kazoo:
+    image: 2600hz/kazoo
+    container_name: kazoo.kazoo
+    hostname: kazoo.kazoo
+    stdin_open: true
+    tty: true
+    environment:
+      - "NETWORK=${NETWORK}"
+      - "COUCHDB=${COUCHDB}"
+      - "RABBITMQ=${RABBITMQ}"
+      - "NODE_NAME=${NODE_NAME}"
+      - "KAZOO_APPS=${KAZOO_APPS}"
+    depends_on:
+      - couchdb.kazoo
+    networks:
+      - kazoo
+
+  kamailio.kazoo:
+    image: 2600hz/kamailio
+    container_name: kamailio.kazoo
+    hostname: kamailio.kazoo
+    environment:
+      - "NETWORK=${NETWORK}"
+      - "RABBITMQ=${RABBITMQ}"
+    depends_on:
+      - kazoo.kazoo
+    ports:
+      - "5060/udp"
+    networks:
+      - kazoo
+
+  freeswitch.kazoo:
+    image: 2600hz/freeswitch
+    container_name: freeswitch.kazoo
+    hostname: freeswitch.kazoo
+    environment:
+      - "RABBITMQ=${RABBITMQ}"
+      - "RTP_START_PORT=${RTP_START_PORT}"
+    depends_on:
+      - kamailio.kazoo
+    ports:
+      - "10000/udp"
+#      - "10000-10999/udp"
+    networks:
+      - kazoo
+
+  monster-ui.kazoo:
+    image: 2600hz/monster-ui
+    container_name: monster-ui.kazoo
+    hostname: monster-ui.kazoo
+    environment:
+      - "NETWORK=${NETWORK}"
+      - "KAZOO=${KAZOO}"
+    depends_on:
+      - freeswitch.kazoo 
+    networks:
+      - kazoo
+

--- a/hosts.sh
+++ b/hosts.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+NETWORK=${1:-"kazoo"}
+NETWORKNAME=${2:-"kazoo"}
+for CONTAINER in monster-ui kazoo rabbitmq freeswitch couchdb
+do
+	if [ "$(docker inspect -f {{.State.Running}} $CONTAINER.$NETWORK)" = "true" ]
+	then
+		echo `bin/get-ip.sh $NETWORKNAME $CONTAINER.$NETWORK` $CONTAINER.$NETWORK
+	fi
+done
+exit


### PR DESCRIPTION
@jamhed 

### Rationale:
**PR Objective:** To be able to have `couchdb` database survive a full start-stop-start cycle of all docker components of kazoo.

In [./bin/run-couchdb.sh](https://github.com/jamhed/kazoo-docker/compare/master...krull:master#diff-3559168d7d04fc7f5c7104aa32d14d92R18), there is now a volume declaration pointing to a host folder `./couchdb_data`. All couchdb data files are saved here and reused on the next docker stop-start cycle.

Moreover, there is a [docker-compose.yml](https://github.com/jamhed/kazoo-docker/compare/master...krull:master#diff-4e5e90c6228fd48698d074241c2ba760), with the attempt to recreate the whole docker environment with `docker-compose`. All environmental parameters are inside [.env](https://github.com/jamhed/kazoo-docker/compare/master...krull:master#diff-f579cccc964135c7d644c7b2d3b0d3ec) needed to run the kazoo docker instances, that docker-compose uses.

Additional files like `hosts.sh` have been added and edited with docker-compose in mind.

**Known issues/Observations:** 
- No known issue in couchdb host directory volume allotment. It runs as expected. Although, from the [official couchdb](https://hub.docker.com/_/couchdb/) there are other options to do persistence of data. This is just one option. millage and use case will vary. 
- In docker-compose, the port udp allotment of range 10000-10999 is an issue. I understood @jamhed's iptables allowances in his run-*.sh bash scripts, but this means that the user will need to run the init scripts as root, and we cannot know the userspace of which docker is ran from on the user's point of view:
> (ie: luser `mcroth` =/= `root`, but `mcroth` runs `./run.sh` and we get `iptables access denied` as a result...)
- [network name in docker-compose](https://docs.docker.com/compose/networking/) follows the format `myapp_default`. At the current state, kazoo-docker creates `kazoodocker_kazoo` network when running `docker-compose up`.

In closing, my use case has been met with the current parameters, for our app. Any other suggestions/comments are appreciated. Here's hoping this contrib is of any use upstream.

**TODO:**
- [ ] Adapt docker methodologies in the image `DockerFile` such as using unified docker system users (ie: user `kazoo` with `uid/gid 999`) across all kazoo docker images. This way the host system will always have a reference `uid/gid 999` other than `root` to depend on for volume management.
- [ ] Other dependencies noticed to make docker ephemeral approach a reality, such as auto removal of networks, docker base library image usage for backend dependencies, `alpine` build use-case, etc... which will help immensely on automated cluster deployments in production.

I guess I'm stick around here more @jamhed heh.. :)

krull